### PR TITLE
safely handle multidoc YAML from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ if __name__ == "__main__":
 ```
 
 ## Demo juju-doctor commands
-```
+```bash
 juju-doctor check --help
 
 juju-doctor check \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,8 @@ dev = [
   "coverage[toml]",
 ]
 
-# [project.urls]
-"Homepage" = "https://github.com/canonical/juju-doctor
+[project.urls]
+"Homepage" = "https://github.com/canonical/juju-doctor"
 "PyPI" = "https://pypi.org/project/juju-doctor"
 # "Bug Tracker" = "?"
 

--- a/src/juju_doctor/main.py
+++ b/src/juju_doctor/main.py
@@ -24,12 +24,15 @@ app = typer.Typer()
 console = Console()
 
 
-def _read_file(filename: Optional[str]) -> Optional[str]:
+def _read_file(filename: Optional[str]) -> Optional[list]:
     """Read a file into a string."""
     if not filename:
         return None
     with open(filename, "r") as f:
-        return f.read()
+        contents = f.read()
+        # Parse all YAML documents and return only the first one
+        # https://github.com/canonical/juju-doctor/issues/10
+        return list(yaml.safe_load_all(contents))[0]
 
 
 def _get_model_data(model: str, probe_category: ProbeCategory) -> str:

--- a/tests/resources/bundle/cos-bundle.yaml
+++ b/tests/resources/bundle/cos-bundle.yaml
@@ -1,0 +1,145 @@
+bundle: kubernetes
+applications:
+  alertmanager:
+    charm: alertmanager-k8s
+    channel: latest/stable
+    revision: 138
+    resources:
+      alertmanager-image: 99
+    scale: 1
+    constraints: arch=amd64
+    storage:
+      data: kubernetes,1,1024M
+    trust: true
+  catalogue:
+    charm: catalogue-k8s
+    channel: latest/stable
+    revision: 75
+    resources:
+      catalogue-image: 34
+    scale: 1
+    options:
+      description: "Canonical Observability Stack Lite, or COS Lite, is a light-weight,
+        highly-integrated, \nJuju-based observability suite running on Kubernetes.\n"
+      tagline: Model-driven Observability Stack deployed with a single command.
+      title: Canonical Observability Stack
+    constraints: arch=amd64
+    trust: true
+  grafana:
+    charm: grafana-k8s
+    channel: latest/stable
+    revision: 126
+    resources:
+      grafana-image: 70
+      litestream-image: 45
+    scale: 1
+    constraints: arch=amd64
+    storage:
+      database: kubernetes,1,1024M
+    trust: true
+  loki:
+    charm: loki-k8s
+    channel: latest/stable
+    revision: 181
+    resources:
+      loki-image: 100
+      node-exporter-image: 3
+    scale: 1
+    constraints: arch=amd64
+    storage:
+      active-index-directory: kubernetes,1,1024M
+      loki-chunks: kubernetes,1,1024M
+    trust: true
+  prometheus:
+    charm: prometheus-k8s
+    channel: latest/stable
+    revision: 221
+    resources:
+      prometheus-image: 151
+    scale: 1
+    constraints: arch=amd64
+    storage:
+      database: kubernetes,1,1024M
+    trust: true
+  traefik:
+    charm: traefik-k8s
+    channel: latest/stable
+    revision: 223
+    resources:
+      traefik-image: 161
+    scale: 1
+    constraints: arch=amd64
+    storage:
+      configurations: kubernetes,1,1024M
+    trust: true
+relations:
+- - traefik:ingress-per-unit
+  - prometheus:ingress
+- - traefik:ingress-per-unit
+  - loki:ingress
+- - traefik:traefik-route
+  - grafana:ingress
+- - traefik:ingress
+  - alertmanager:ingress
+- - prometheus:alertmanager
+  - alertmanager:alerting
+- - grafana:grafana-source
+  - prometheus:grafana-source
+- - grafana:grafana-source
+  - loki:grafana-source
+- - grafana:grafana-source
+  - alertmanager:grafana-source
+- - loki:alertmanager
+  - alertmanager:alerting
+- - prometheus:metrics-endpoint
+  - traefik:metrics-endpoint
+- - prometheus:metrics-endpoint
+  - alertmanager:self-metrics-endpoint
+- - prometheus:metrics-endpoint
+  - loki:metrics-endpoint
+- - prometheus:metrics-endpoint
+  - grafana:metrics-endpoint
+- - grafana:grafana-dashboard
+  - loki:grafana-dashboard
+- - grafana:grafana-dashboard
+  - prometheus:grafana-dashboard
+- - grafana:grafana-dashboard
+  - alertmanager:grafana-dashboard
+- - catalogue:ingress
+  - traefik:ingress
+- - catalogue:catalogue
+  - grafana:catalogue
+- - catalogue:catalogue
+  - prometheus:catalogue
+- - catalogue:catalogue
+  - alertmanager:catalogue
+--- # overlay.yaml
+applications:
+  alertmanager:
+    offers:
+      alertmanager-karma-dashboard:
+        endpoints:
+        - karma-dashboard
+        acl:
+          admin: admin
+  grafana:
+    offers:
+      grafana-dashboards:
+        endpoints:
+        - grafana-dashboard
+        acl:
+          admin: admin
+  loki:
+    offers:
+      loki-logging:
+        endpoints:
+        - logging
+        acl:
+          admin: admin
+  prometheus:
+    offers:
+      prometheus-receive-remote-write:
+        endpoints:
+        - receive-remote-write
+        acl:
+          admin: admin

--- a/tests/resources/bundle/failing.py
+++ b/tests/resources/bundle/failing.py
@@ -8,5 +8,5 @@ import yaml
 
 if __name__ == "__main__":
     data = yaml.safe_load(sys.stdin)
-    print("This probe always fails!")
+    print("This probe always fails!", file=sys.stderr)
     exit(1)

--- a/tests/resources/show-unit/failing.py
+++ b/tests/resources/show-unit/failing.py
@@ -8,5 +8,5 @@ import yaml
 
 if __name__ == "__main__":
     data = yaml.safe_load(sys.stdin)
-    print("This probe always fails!")
+    print("This probe always fails!", file=sys.stderr)
     exit(1)


### PR DESCRIPTION
Fixes: #10 

Tested with
```
juju-doctor check \
    --probe "github://canonical/grafana-agent-operator//probes/bundle" \
    --bundle "tests/resources/bundle/cos-bundle.yaml"
```

The new functionality strips any following docs, keeping only the first one.