### PR TITLE
feat: PyPI CI releases

### DIFF
--- a/.github/workflows/quality-checks.yaml
+++ b/.github/workflows/quality-checks.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_call:
 
 jobs:
   lint:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,3 @@
-# TODO Ref from: https://github.com/canonical/cos-lib/blob/main/.github/workflows/release.yaml
-# https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
 name: Release to PyPI
 
 # on:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,15 +1,9 @@
 name: Release to PyPI
 
-# TODO Uncomment
-# on:
-#   release:
-#     types: [published]
-
-# TODO Remove
 on:
-  pull_request:
-    branches:
-      - main
+  release:
+    types:
+    - published
 
 jobs:
   quality:
@@ -43,7 +37,6 @@ jobs:
 
   publish-to-pypi:
     name: Publish Python 🐍 distribution 📦 to PyPI
-    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
     needs:
     - build
     runs-on: ubuntu-latest
@@ -53,6 +46,18 @@ jobs:
     permissions:
       id-token: write  # mandatory for trusted publishing
     steps:
+    - name: Auto set pyproject.toml version from tag
+      # Ref: https://github.com/grst/python-ci-versioneer
+      run: |
+        # from refs/tags/1.2.3 get 1.2.3
+        VERSION=$(echo $GITHUB_REF | sed 's#.*/##')
+        echo "Setting version to $VERSION"
+        PLACEHOLDER='^version\s*=.*'
+        # ensure the placeholder is there. If grep doesn't find the placeholder
+        # it exits with exit code 1 and github actions aborts the build.
+        grep -E "$PLACEHOLDER" pyproject.toml
+        sed -i -e "s/^\(version\s*=\).*/\1 \"${VERSION}\"/g" pyproject.toml
+      shell: bash
     - name: Download all the dists
       uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,84 @@
+# TODO Ref from: https://github.com/canonical/cos-lib/blob/main/.github/workflows/release.yaml
+# https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+name: Release to PyPI
+
+# on:
+#   release:
+#     types: [published]
+
+on:
+  pull_request:
+    branches:
+      - feat/pypi-ci
+
+jobs:
+  quality:
+    uses: ./.github/workflows/quality-checks.yaml
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+    needs: 
+    - quality
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install pypa/build
+        run: >-
+          python3 -m
+          pip install
+          build
+          --user
+      - name: Build a binary wheel and a source tarball
+        run: python3 -m build
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-to-testpypi:
+    name: Publish Python 🐍 distribution 📦 to TestPyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/<package-name>
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+
+  # publish-to-pypi:
+  #   name: >-
+  #     Publish Python 🐍 distribution 📦 to PyPI
+  #   if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+  #   needs:
+  #   - build
+  #   runs-on: ubuntu-latest
+  #   environment:
+  #     name: pypi
+  #     url: https://pypi.org/p/juju-doctor
+  #   permissions:
+  #     id-token: write  # mandatory for trusted publishing
+  #   steps:
+  #   - name: Download all the dists
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       name: python-package-distributions
+  #       path: dist/
+  #   - name: Publish distribution 📦 to PyPI
+  #     uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ name: Release to PyPI
 on:
   pull_request:
     branches:
-      - feat/pypi-ci
+      - main
 
 jobs:
   quality:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,11 @@
 name: Release to PyPI
 
+# TODO Uncomment
 # on:
 #   release:
 #     types: [published]
 
+# TODO Remove
 on:
   pull_request:
     branches:
@@ -39,44 +41,22 @@ jobs:
           name: python-package-distributions
           path: dist/
 
-  publish-to-testpypi:
-    name: Publish Python 🐍 distribution 📦 to TestPyPI
+  publish-to-pypi:
+    name: Publish Python 🐍 distribution 📦 to PyPI
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
     needs:
     - build
     runs-on: ubuntu-latest
     environment:
-      name: testpypi
-      url: https://test.pypi.org/p/<package-name>
+      name: pypi
+      url: https://pypi.org/p/juju-doctor
     permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
+      id-token: write  # mandatory for trusted publishing
     steps:
     - name: Download all the dists
       uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
-    - name: Publish distribution 📦 to TestPyPI
+    - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        repository-url: https://test.pypi.org/legacy/
-
-  # publish-to-pypi:
-  #   name: >-
-  #     Publish Python 🐍 distribution 📦 to PyPI
-  #   if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
-  #   needs:
-  #   - build
-  #   runs-on: ubuntu-latest
-  #   environment:
-  #     name: pypi
-  #     url: https://pypi.org/p/juju-doctor
-  #   permissions:
-  #     id-token: write  # mandatory for trusted publishing
-  #   steps:
-  #   - name: Download all the dists
-  #     uses: actions/download-artifact@v4
-  #     with:
-  #       name: python-package-distributions
-  #       path: dist/
-  #   - name: Publish distribution 📦 to PyPI
-  #     uses: pypa/gh-action-pypi-publish@release/v1

--- a/tests/unit/probe_uri_parsing/test_github_protocol.py
+++ b/tests/unit/probe_uri_parsing/test_github_protocol.py
@@ -1,47 +1,42 @@
 import tempfile
 from pathlib import Path
 
-import pytest
 from fetcher import Fetcher
 
 
-@pytest.mark.parametrize("category", ["status", "bundle", "show-unit"])
-def test_parse_file(category):
+def test_parse_file():
     # GIVEN a probe file specified in a Github remote on the main branch
-    probe_uri = f"github://canonical/juju-doctor//tests/resources/{category}/failing.py?main"
+    probe_uri = "github://canonical/juju-doctor//tests/resources/failing.py?main"
     with tempfile.TemporaryDirectory() as tmpdir:
-        fetcher = Fetcher(Path(tmpdir))
         # WHEN the probes are fetched to a local filesystem
-        probes = fetcher.fetch_probes(uri=probe_uri)
+        probes = Fetcher.fetch_probes(destination=Path(tmpdir), uri=probe_uri)
         # THEN only 1 probe exists
         assert len(probes) == 1
         probe = probes[0]
         # AND the Probe was correctly parsed
         assert probe.uri == probe_uri
-        assert probe.name == f"canonical_juju-doctor__tests_resources_{category}_failing.py"
-        assert probe.original_path == Path(f"tests/resources/{category}/failing.py")
+        assert probe.name == "canonical_juju-doctor__tests_resources_failing.py"
+        assert probe.original_path == Path("tests/resources/failing.py")
         assert probe.path == Path(tmpdir) / probe.name
 
 
-@pytest.mark.parametrize("category", ["status", "bundle", "show-unit"])
-def test_parse_dir(category):
+def test_parse_dir():
     # GIVEN a probe directory specified in a Github remote on the main branch
-    probe_uri = f"github://canonical/juju-doctor//tests/resources/{category}?main"
+    probe_uri = "github://canonical/juju-doctor//tests/resources?main"
     with tempfile.TemporaryDirectory() as tmpdir:
-        fetcher = Fetcher(Path(tmpdir))
         # WHEN the probes are fetched to a local filesystem
-        probes = fetcher.fetch_probes(uri=probe_uri)
+        probes = Fetcher.fetch_probes(destination=Path(tmpdir), uri=probe_uri)
         # THEN 2 probe exists
         assert len(probes) == 2
         passing_probe = [probe for probe in probes if "passing.py" in probe.name][0]
         failing_probe = [probe for probe in probes if "failing.py" in probe.name][0]
         # AND the Probe was correctly parsed as passing
         assert passing_probe.uri == probe_uri
-        assert passing_probe.name == f"canonical_juju-doctor__tests_resources_{category}/passing.py"
-        assert passing_probe.original_path == Path(f"tests/resources/{category}")
+        assert passing_probe.name == "canonical_juju-doctor__tests_resources/passing.py"
+        assert passing_probe.original_path == Path("tests/resources")
         assert passing_probe.path == Path(tmpdir) / passing_probe.name
         # AND the Probe was correctly parsed as failing
         assert failing_probe.uri == probe_uri
-        assert failing_probe.name == f"canonical_juju-doctor__tests_resources_{category}/failing.py"
-        assert failing_probe.original_path == Path(f"tests/resources/{category}")
+        assert failing_probe.name == "canonical_juju-doctor__tests_resources/failing.py"
+        assert failing_probe.original_path == Path("tests/resources")
         assert failing_probe.path == Path(tmpdir) / failing_probe.name

--- a/tests/unit/probe_uri_parsing/test_github_protocol.py
+++ b/tests/unit/probe_uri_parsing/test_github_protocol.py
@@ -8,8 +8,9 @@ def test_parse_file():
     # GIVEN a probe file specified in a Github remote on the main branch
     probe_uri = "github://canonical/juju-doctor//tests/resources/failing.py?main"
     with tempfile.TemporaryDirectory() as tmpdir:
+        fetcher = Fetcher(Path(tmpdir))
         # WHEN the probes are fetched to a local filesystem
-        probes = Fetcher.fetch_probes(destination=Path(tmpdir), uri=probe_uri)
+        probes = fetcher.fetch_probes(uri=probe_uri)
         # THEN only 1 probe exists
         assert len(probes) == 1
         probe = probes[0]
@@ -24,8 +25,9 @@ def test_parse_dir():
     # GIVEN a probe directory specified in a Github remote on the main branch
     probe_uri = "github://canonical/juju-doctor//tests/resources?main"
     with tempfile.TemporaryDirectory() as tmpdir:
+        fetcher = Fetcher(Path(tmpdir))
         # WHEN the probes are fetched to a local filesystem
-        probes = Fetcher.fetch_probes(destination=Path(tmpdir), uri=probe_uri)
+        probes = fetcher.fetch_probes(uri=probe_uri)
         # THEN 2 probe exists
         assert len(probes) == 2
         passing_probe = [probe for probe in probes if "passing.py" in probe.name][0]


### PR DESCRIPTION
Refs:
- [cos-lib CI](https://github.com/canonical/cos-lib/blob/main/.github/workflows/release.yaml)
- [guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/)

## TODO
- [ ] Publish to TestPyPI
- [ ] Publish PyPI
- [ ] Setup GH repo env name (need admin privs)
> The name of the [GitHub Actions environment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) that the above workflow uses for publishing. This should be configured under the repository's settings. While not required, a dedicated publishing environment is strongly encouraged, especially if your repository has maintainers with commit access who shouldn't have PyPI publishing access.
