### PR TITLE
fix: unit test for gh dir probes

### DIFF
--- a/tests/unit/probe_uri_parsing/test_github_protocol.py
+++ b/tests/unit/probe_uri_parsing/test_github_protocol.py
@@ -6,20 +6,20 @@ import pytest
 from juju_doctor.probes import Probe
 
 
-# @pytest.mark.github
-# def test_parse_file():
-#     # GIVEN a probe file specified in a Github remote on the main branch
-#     path_str = "tests/resources/probes/python/failing.py"
-#     probe_url = f"github://canonical/juju-doctor//{path_str}?main"
-#     with tempfile.TemporaryDirectory() as tmpdir:
-#         # WHEN the probes are fetched to a local filesystem
-#         probes = Probe.from_url(url=probe_url, probes_root=Path(tmpdir))
-#         # THEN only 1 probe exists
-#         assert len(probes) == 1
-#         probe = probes[0]
-#         # AND the Probe was correctly parsed
-#         assert probe.name == "canonical_juju-doctor__tests_resources_probes_python_failing.py"
-#         assert probe.path == Path(tmpdir) / probe.name
+@pytest.mark.github
+def test_parse_file():
+    # GIVEN a probe file specified in a Github remote on the main branch
+    path_str = "tests/resources/probes/python/failing.py"
+    probe_url = f"github://canonical/juju-doctor//{path_str}?main"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # WHEN the probes are fetched to a local filesystem
+        probes = Probe.from_url(url=probe_url, probes_root=Path(tmpdir))
+        # THEN only 1 probe exists
+        assert len(probes) == 1
+        probe = probes[0]
+        # AND the Probe was correctly parsed
+        assert probe.name == "canonical_juju-doctor__tests_resources_probes_python_failing.py"
+        assert probe.path == Path(tmpdir) / probe.name
 
 
 @pytest.mark.github

--- a/tests/unit/probe_uri_parsing/test_github_protocol.py
+++ b/tests/unit/probe_uri_parsing/test_github_protocol.py
@@ -6,20 +6,20 @@ import pytest
 from juju_doctor.probes import Probe
 
 
-@pytest.mark.github
-def test_parse_file():
-    # GIVEN a probe file specified in a Github remote on the main branch
-    path_str = "tests/resources/probes/python/failing.py"
-    probe_url = f"github://canonical/juju-doctor//{path_str}?main"
-    with tempfile.TemporaryDirectory() as tmpdir:
-        # WHEN the probes are fetched to a local filesystem
-        probes = Probe.from_url(url=probe_url, probes_root=Path(tmpdir))
-        # THEN only 1 probe exists
-        assert len(probes) == 1
-        probe = probes[0]
-        # AND the Probe was correctly parsed
-        assert probe.name == "canonical_juju-doctor__tests_resources_probes_python_failing.py"
-        assert probe.path == Path(tmpdir) / probe.name
+# @pytest.mark.github
+# def test_parse_file():
+#     # GIVEN a probe file specified in a Github remote on the main branch
+#     path_str = "tests/resources/probes/python/failing.py"
+#     probe_url = f"github://canonical/juju-doctor//{path_str}?main"
+#     with tempfile.TemporaryDirectory() as tmpdir:
+#         # WHEN the probes are fetched to a local filesystem
+#         probes = Probe.from_url(url=probe_url, probes_root=Path(tmpdir))
+#         # THEN only 1 probe exists
+#         assert len(probes) == 1
+#         probe = probes[0]
+#         # AND the Probe was correctly parsed
+#         assert probe.name == "canonical_juju-doctor__tests_resources_probes_python_failing.py"
+#         assert probe.path == Path(tmpdir) / probe.name
 
 
 @pytest.mark.github
@@ -30,17 +30,9 @@ def test_parse_dir():
     with tempfile.TemporaryDirectory() as tmpdir:
         # WHEN the probes are fetched to a local filesystem
         probes = Probe.from_url(url=probe_url, probes_root=Path(tmpdir))
-        # THEN 2 probe exists
-        assert len(probes) == 2
-        passing_probe = [probe for probe in probes if "passing.py" in probe.name][0]
-        failing_probe = [probe for probe in probes if "failing.py" in probe.name][0]
-        # AND the Probe was correctly parsed as passing
-        assert (
-            passing_probe.name == "canonical_juju-doctor__tests_resources_probes_python/passing.py"
-        )
-        assert passing_probe.path == Path(tmpdir) / passing_probe.name
-        # AND the Probe was correctly parsed as failing
-        assert (
-            failing_probe.name == "canonical_juju-doctor__tests_resources_probes_python/failing.py"
-        )
-        assert failing_probe.path == Path(tmpdir) / failing_probe.name
+        # THEN each Probe is correctly parsed
+        for probe in probes:
+            file_name = probe.name.split("/")[-1]
+            url_flattened = f"{'tests/resources/probes/python'.replace('/', '_')}/{file_name}"
+            assert probe.name == f"canonical_juju-doctor__{url_flattened}"
+            assert probe.path == Path(tmpdir) / probe.name


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
1. The test was brittle and fails when we add probes to `tests/resources/probes/python`
2. This is failing CI on main

## Solution
<!-- A summary of the solution addressing the above issue -->
Make it less brittle and making it more DRY

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
`tox -e unit`

## Upgrade Notes
<!-- To upgrade from an older revision of juju-doctor, ... -->
