### PR TITLE
improve: housekeeping after sprint workshop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ extend-exclude = ["__pycache__", "*.egg_info"]
 select = ["E", "W", "F", "C", "N", "R", "D", "I001"]
 ignore = ["C901"]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = {"tests/*" = ["D100","D101","D102","D103"], "tests/constants.py" = ["E501"]}
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","E501"]}
 extend-select = ["I"]
 
 [tool.ruff.lint.pydocstyle]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ extend-exclude = ["__pycache__", "*.egg_info"]
 select = ["E", "W", "F", "C", "N", "R", "D", "I001"]
 ignore = ["C901"]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","E501"]}
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103"]}
 extend-select = ["I"]
 
 [tool.ruff.lint.pydocstyle]

--- a/src/juju_doctor/fetcher.py
+++ b/src/juju_doctor/fetcher.py
@@ -80,7 +80,7 @@ def copy_probes(
         rpath = f"{path.as_posix()}/" if path.is_dir() else path.as_posix()
         lpath = probes_destination.as_posix()
         if Path(lpath).exists():
-            log.warn(f"Duplicate file ({rpath}) detected, its contents will be overwritten.")
+            log.warning(f"Duplicate file ({rpath}) detected, it will be skipped.")
         filesystem.get(rpath, lpath, recursive=True, auto_mkdir=True)
     except FileNotFoundError as e:
         log.warning(

--- a/src/juju_doctor/fetcher.py
+++ b/src/juju_doctor/fetcher.py
@@ -80,7 +80,7 @@ def copy_probes(
         rpath = f"{path.as_posix()}/" if path.is_dir() else path.as_posix()
         lpath = probes_destination.as_posix()
         if Path(lpath).exists():
-            log.warning(f"Duplicate file ({rpath}) detected, it will be skipped.")
+            log.warning(f"Duplicate file detected: {rpath}, it will be skipped.")
         filesystem.get(rpath, lpath, recursive=True, auto_mkdir=True)
     except FileNotFoundError as e:
         log.warning(

--- a/src/juju_doctor/fetcher.py
+++ b/src/juju_doctor/fetcher.py
@@ -80,7 +80,7 @@ def copy_probes(
         rpath = f"{path.as_posix()}/" if path.is_dir() else path.as_posix()
         lpath = probes_destination.as_posix()
         if Path(lpath).exists():
-            log.warning(f"Duplicate file detected: {rpath}, it will be skipped.")
+            log.warning(f"Duplicate file detected: ./{rpath}, it will be skipped.")
         filesystem.get(rpath, lpath, recursive=True, auto_mkdir=True)
     except FileNotFoundError as e:
         log.warning(

--- a/src/juju_doctor/main.py
+++ b/src/juju_doctor/main.py
@@ -78,7 +78,7 @@ def check(
         if probe_url not in unique_probe_urls:
             unique_probe_urls.add(probe_url)
         else:
-            log.warning(f"Duplicate probe detected: {probe_url}")
+            log.warning(f"Duplicate probe detected: {probe_url}, it will be skipped.")
 
     # Gather the input
     input: Dict[str, ModelArtifact] = {}

--- a/src/juju_doctor/main.py
+++ b/src/juju_doctor/main.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Annotated, Dict, List, Optional
 
 import typer
+from rich.console import Console
 from rich.logging import RichHandler
 
 from juju_doctor.artifacts import Artifacts, ModelArtifact
@@ -20,13 +21,15 @@ log = logging.getLogger(__name__)
 
 # TODO Add test for no args prints help??
 app = typer.Typer(pretty_exceptions_show_locals=False, no_args_is_help=True)
+console = Console()
 sys.setrecursionlimit(150)  # Protect against cirular RuleSet executions, increase if needed
 
 
-# Ask Luca why commenting this out fails, works with it
-@app.command()
-def fake():
-    log.warn(f"FAILING")
+@app.command(hidden=True)
+def help():
+    """With only 1 app.command, juju-doctor will not run `--help` by default when no args are supplied."""
+    # TODO Remove this command when a second, valid command is added
+    console.print("Try again without args: [i]juju-doctor[/i] or [i]juju-doctor --help[/i]")  # https://github.com/fastapi/typer/issues/315#issuecomment-903221890
 
 
 @app.command()

--- a/src/juju_doctor/main.py
+++ b/src/juju_doctor/main.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Annotated, Dict, List, Optional
 
 import typer
-from rich.console import Console
 from rich.logging import RichHandler
 
 from juju_doctor.artifacts import Artifacts, ModelArtifact
@@ -19,9 +18,15 @@ from juju_doctor.tree import OutputFormat, ProbeResultAggregator
 logging.basicConfig(level=logging.WARN, handlers=[RichHandler()])
 log = logging.getLogger(__name__)
 
-app = typer.Typer(pretty_exceptions_show_locals=False)
-console = Console()
+# TODO Add test for no args prints help??
+app = typer.Typer(pretty_exceptions_show_locals=False, no_args_is_help=True)
 sys.setrecursionlimit(150)  # Protect against cirular RuleSet executions, increase if needed
+
+
+# Ask Luca why commenting this out fails, works with it
+@app.command()
+def fake():
+    log.warn(f"FAILING")
 
 
 @app.command()
@@ -100,12 +105,6 @@ def check(
         output_fmt = OutputFormat(verbose, format)
         aggregator = ProbeResultAggregator(probe_results, output_fmt)
         aggregator.print_results()
-
-
-@app.command()
-def help():
-    """Show the help information for juju-doctor."""
-    app().help()
 
 
 if __name__ == "__main__":

--- a/src/juju_doctor/main.py
+++ b/src/juju_doctor/main.py
@@ -25,11 +25,9 @@ console = Console()
 sys.setrecursionlimit(150)  # Protect against cirular RuleSet executions, increase if needed
 
 
-@app.command(hidden=True)
-def help():
-    """With only 1 app.command, juju-doctor will not run `--help` by default when no args are supplied."""
-    # TODO Remove this command when a second, valid command is added
-    console.print("Try again without args: [i]juju-doctor[/i] or [i]juju-doctor --help[/i]")  # https://github.com/fastapi/typer/issues/315#issuecomment-903221890
+@app.callback()
+def callback():
+    """Collect, execute, and aggregate assertions against artifacts, which represent a deployment."""
 
 
 @app.command()
@@ -63,7 +61,7 @@ def check(
         typer.Option("--format", "-o", help="Specify output format."),
     ] = None,
 ):
-    """Run checks on a certain model."""
+    """Validate online or offline deployments, i.e. artifacts against local or remote assertions, i.e. probes."""
     # Input validation
     if models and any([status_files, bundle_files, show_unit_files]):
         raise typer.BadParameter(

--- a/src/juju_doctor/main.py
+++ b/src/juju_doctor/main.py
@@ -29,7 +29,7 @@ def callback():
     """Collect, execute, and aggregate assertions against artifacts, representing a deployment."""
 
 
-@app.command()
+@app.command(no_args_is_help=True)
 def check(
     probe_urls: Annotated[
         List[str],

--- a/src/juju_doctor/main.py
+++ b/src/juju_doctor/main.py
@@ -19,7 +19,6 @@ from juju_doctor.tree import OutputFormat, ProbeResultAggregator
 logging.basicConfig(level=logging.WARN, handlers=[RichHandler()])
 log = logging.getLogger(__name__)
 
-# TODO Add test for no args prints help??
 app = typer.Typer(pretty_exceptions_show_locals=False, no_args_is_help=True)
 console = Console()
 sys.setrecursionlimit(150)  # Protect against cirular RuleSet executions, increase if needed

--- a/src/juju_doctor/main.py
+++ b/src/juju_doctor/main.py
@@ -26,11 +26,14 @@ sys.setrecursionlimit(150)  # Protect against cirular RuleSet executions
 
 @app.callback()
 def callback():
+    # When only 1 app.command exists, it is executed with `juju-doctor`, instead of the intended
+    # help menu. app.callback overrides the CLI parameters for (without args) `juju-doctor`.
     """Collect, execute, and aggregate assertions against artifacts, representing a deployment."""
 
 
 @app.command(no_args_is_help=True)
 def check(
+    ctx: typer.Context,
     probe_urls: Annotated[
         List[str],
         typer.Option("--probe", "-p", help="URL of a probe containing probes to execute."),
@@ -79,7 +82,13 @@ def check(
         if probe_url not in unique_probe_urls:
             unique_probe_urls.add(probe_url)
         else:
-            log.warning(f"Duplicate probe detected: {probe_url}, it will be skipped.")
+            log.warning(f"Duplicate probe arg detected: {probe_url}, it will be skipped.")
+
+    supplied_artifacts = {
+        key.removesuffix("_files")
+        for key, param in ctx.params.items()
+        if key.endswith("_files") and param
+    }
 
     # Gather the input
     input: Dict[str, ModelArtifact] = {}
@@ -113,8 +122,16 @@ def check(
 
         # Run the probes
         probe_results = {}
+        check_functions = set()
         for probe in probes:
+            check_functions |= set(probe.get_functions().keys())
             probe_results[probe.name] = probe.run(artifacts)
+
+        if not supplied_artifacts.issubset(check_functions):
+            useless_artifacts = ", ".join(supplied_artifacts - check_functions)
+            log.warning(
+                f"The '{useless_artifacts}' artifact was supplied, but not used by any probes."
+            )
 
         output_fmt = OutputFormat(verbose, format)
         aggregator = ProbeResultAggregator(probe_results, output_fmt)

--- a/src/juju_doctor/main.py
+++ b/src/juju_doctor/main.py
@@ -67,8 +67,9 @@ def check(
     * Assertions can be sourced (local) from the current FS or (remote) from repositories.
     """
     # Input validation
+    # TODO We need a way to make the artifact names dynamic. We have this with SUPPORTED_PROBE_FUNCTIONS, maybe a good time to introduce a constants.py?
     if models and any([status_files, bundle_files, show_unit_files]):
-        raise typer.BadParameter("Live models and static files are mutually exclusive.")
+        raise typer.BadParameter("Live models (--model) and static files are mutually exclusive.")
     if not any([models, status_files, bundle_files, show_unit_files]):
         raise typer.BadParameter("No artifacts were specified, cannot validate the deployment.")
 
@@ -113,6 +114,7 @@ def check(
 
         # Run the probes
         probe_results = {}
+        # TODO Explain in PR and issue that checking for "artifact supplied, but no probes use it" is not really helpful bc then we would need a way to know which probes do not use this artifact, but this is also useless bc if a new probe gets added which does use the artifact, then the ERROR is gone. This also add computational effort.
         for probe in probes:
             probe_results[probe.name] = probe.run(artifacts)
 

--- a/src/juju_doctor/main.py
+++ b/src/juju_doctor/main.py
@@ -67,7 +67,6 @@ def check(
     * Assertions can be sourced (local) from the current FS or (remote) from repositories.
     """
     # Input validation
-    # TODO We need a way to make the artifact names dynamic. We have this with SUPPORTED_PROBE_FUNCTIONS, maybe a good time to introduce a constants.py?
     if models and any([status_files, bundle_files, show_unit_files]):
         raise typer.BadParameter("Live models (--model) and static files are mutually exclusive.")
     if not any([models, status_files, bundle_files, show_unit_files]):
@@ -114,7 +113,6 @@ def check(
 
         # Run the probes
         probe_results = {}
-        # TODO Explain in PR and issue that checking for "artifact supplied, but no probes use it" is not really helpful bc then we would need a way to know which probes do not use this artifact, but this is also useless bc if a new probe gets added which does use the artifact, then the ERROR is gone. This also add computational effort.
         for probe in probes:
             probe_results[probe.name] = probe.run(artifacts)
 

--- a/src/juju_doctor/main.py
+++ b/src/juju_doctor/main.py
@@ -26,7 +26,7 @@ sys.setrecursionlimit(150)  # Protect against cirular RuleSet executions, increa
 
 @app.callback()
 def callback():
-    """Collect, execute, and aggregate assertions against artifacts, which represent a deployment."""
+    """Collect, execute, and aggregate assertions against artifacts, representing a deployment."""
 
 
 @app.command()
@@ -60,7 +60,12 @@ def check(
         typer.Option("--format", "-o", help="Specify output format."),
     ] = None,
 ):
-    """Validate online or offline deployments, i.e. artifacts against local or remote assertions, i.e. probes."""
+    """Validate deployments, i.e. artifacts against assertions, i.e. probes.
+
+    * Deployments can be (online) a live model or (offline) an artifact file.
+
+    * Assertions can be sourced (local) from the current FS or (remote) from repositories.
+    """
     # Input validation
     if models and any([status_files, bundle_files, show_unit_files]):
         raise typer.BadParameter(

--- a/src/juju_doctor/main.py
+++ b/src/juju_doctor/main.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 
 app = typer.Typer(pretty_exceptions_show_locals=False, no_args_is_help=True)
 console = Console()
-sys.setrecursionlimit(150)  # Protect against cirular RuleSet executions, increase if needed
+sys.setrecursionlimit(150)  # Protect against cirular RuleSet executions
 
 
 @app.callback()
@@ -68,9 +68,10 @@ def check(
     """
     # Input validation
     if models and any([status_files, bundle_files, show_unit_files]):
-        raise typer.BadParameter(
-            "If you pass a live model with --model, you cannot pass static files."
-        )
+        raise typer.BadParameter("Live models and static files are mutually exclusive.")
+    if not any([models, status_files, bundle_files, show_unit_files]):
+        raise typer.BadParameter("No artifacts were specified, cannot validate the deployment.")
+
     if not probe_urls:
         raise typer.BadParameter("No probes were specified, cannot validate the deployment.")
     unique_probe_urls: Set[str] = set()

--- a/src/juju_doctor/main.py
+++ b/src/juju_doctor/main.py
@@ -71,6 +71,10 @@ def check(
         raise typer.BadParameter(
             "If you pass a live model with --model, you cannot pass static files."
         )
+    if not probe_urls:
+        raise typer.BadParameter(
+            "No probes were specified, cannot validate the deployment."
+        )
 
     # Gather the input
     input: Dict[str, ModelArtifact] = {}

--- a/src/juju_doctor/probes.py
+++ b/src/juju_doctor/probes.py
@@ -258,7 +258,7 @@ class RuleSet:
                         and Path(ruleset_probe["url"]).suffix.lower()
                         not in FileExtensions.PYTHON.value
                     ):
-                        log.warn(
+                        log.warning(
                             f"{ruleset_probe['url']} is not a scriptlet but was specified as such."
                         )
                         return []
@@ -273,7 +273,7 @@ class RuleSet:
                         and Path(ruleset_probe["url"]).suffix.lower()
                         not in FileExtensions.RULESET.value
                     ):
-                        log.warn(
+                        log.warning(
                             f"{ruleset_probe['url']} is not a ruleset but was specified as such."
                         )
                         return []

--- a/src/juju_doctor/probes.py
+++ b/src/juju_doctor/probes.py
@@ -12,7 +12,6 @@ from uuid import UUID, uuid4
 
 import fsspec
 import yaml
-from rich.console import Console
 from rich.logging import RichHandler
 
 from juju_doctor.artifacts import Artifacts
@@ -22,8 +21,6 @@ SUPPORTED_PROBE_FUNCTIONS = ["status", "bundle", "show_unit"]
 
 logging.basicConfig(level=logging.WARN, handlers=[RichHandler()])
 log = logging.getLogger(__name__)
-
-console = Console()
 
 
 class AssertionStatus(Enum):

--- a/src/juju_doctor/tree.py
+++ b/src/juju_doctor/tree.py
@@ -101,13 +101,14 @@ class ProbeResultAggregator:
         results = self._build_tree()
         passed = results[AssertionStatus.PASS.value]
         failed = results[AssertionStatus.FAIL.value]
+        total = passed + failed
         match self._output_fmt.format:
             case None:
                 self._tree.show()
                 for e in filter(None, self._exceptions):
                     console.print(e)
                 console.print(
-                    f"\nTotal: 🟢 {passed} 🔴 {failed}"
+                    f"\nTotal: 🟢 {passed}/{total} 🔴 {failed}/{total}"
                 )
             case "json":
                 tree_json = json.loads(self._tree.to_json())

--- a/src/juju_doctor/tree.py
+++ b/src/juju_doctor/tree.py
@@ -26,22 +26,9 @@ class OutputFormat:
     rich_map = {
         "green": "🟢",
         "red": "🔴",
+        "check_mark": "✔️",
+        "multiply": "✖️",
     }
-
-
-class RichTree(Tree):
-    """A subclass of treelib.Tree that renders styled text from shortcodes."""
-
-    def show(self, *args, **kwargs):
-        """Overrides Tree::show to replace shortcodes with styled text."""
-        output = super().show(*args, stdout=False)  # Get tree output as string
-        if output:
-            for shortcode, styled_text in OutputFormat.rich_map.items():
-                output = output.replace(shortcode, styled_text)
-        else:
-            output = "Error: No tree output available."
-        if kwargs.get("stdout", True):
-            console.print(output)
 
 
 class ProbeResultAggregator:
@@ -53,7 +40,7 @@ class ProbeResultAggregator:
         """Prepare the aggregated results and its tree representation."""
         self._output_fmt = output_fmt
         self._exceptions = []
-        self._tree = RichTree()
+        self._tree = Tree()
         self._tree.create_node("Results", "root")  # root node
         self._grouped_by_status = defaultdict(list)
         self._group_results(probe_results)
@@ -74,30 +61,37 @@ class ProbeResultAggregator:
         Create a new node in the tree once per defined probe with an assertion summary.
         """
         results = {AssertionStatus.PASS.value: 0, AssertionStatus.FAIL.value: 0}
-        for status, probe_results in self._grouped_by_status.items():
-            self._tree.create_node(str(status), status, parent="root")
+        for probe_status, probe_results in self._grouped_by_status.items():
+            self._tree.create_node(str(probe_status), probe_status, parent="root")
             for probe_result in probe_results:
                 node_tag = ""
-                function_statuses = {"pass": [], "fail": []}
-                # gather failed assertions and exceptions
+                func_statuses = []
                 assertion_result = None
+                # gather failed assertions and exceptions
                 for assertion_result in probe_result:
                     node_tag, probe_exception = assertion_result.get_text(self._output_fmt)
                     results[assertion_result.status] += 1
                     if probe_exception:
                         self._exceptions.append(probe_exception)
-                    function_statuses[assertion_result.status].append(assertion_result.func_name)
-                    if not assertion_result.passed:
-                        node_tag += f" ({', '.join(function_statuses[status])})"
+                    symbol = (
+                        self._output_fmt.rich_map["check_mark"]
+                        if assertion_result.status == AssertionStatus.PASS.value
+                        else self._output_fmt.rich_map["multiply"]
+                    )
+                    func_statuses.append(f"{symbol} {assertion_result.func_name}")
+
+                node_tag += f" ({', '.join(func_statuses)})"
                 # The `probe` attribute for each `assertion_result` in a given `probe_result` will
                 # be identical, so we can create the tree node with the last `assertion_result`
                 if assertion_result:
-                    self._tree.create_node(node_tag, assertion_result.probe.get_chain(), status)
+                    self._tree.create_node(
+                        node_tag, assertion_result.probe.get_chain(), probe_status
+                    )
 
         return results
 
     def print_results(self):
-        """Handle the formating and logging of probe results."""
+        """Handle the formatting and logging of probe results."""
         results = self._build_tree()
         passed = results[AssertionStatus.PASS.value]
         failed = results[AssertionStatus.FAIL.value]
@@ -107,9 +101,7 @@ class ProbeResultAggregator:
                 self._tree.show()
                 for e in filter(None, self._exceptions):
                     console.print(e)
-                console.print(
-                    f"\nTotal: 🟢 {passed}/{total} 🔴 {failed}/{total}"
-                )
+                console.print(f"\nTotal: 🟢 {passed}/{total} 🔴 {failed}/{total}")
             case "json":
                 tree_json = json.loads(self._tree.to_json())
                 # TODO see if treelib.Tree.to_json has an option to remove the "children" keys

--- a/src/juju_doctor/tree.py
+++ b/src/juju_doctor/tree.py
@@ -80,7 +80,8 @@ class ProbeResultAggregator:
                     )
                     func_statuses.append(f"{symbol} {assertion_result.func_name}")
 
-                node_tag += f" ({', '.join(func_statuses)})"
+                if self._output_fmt.verbose:
+                    node_tag += f" ({', '.join(func_statuses)})"
                 # The `probe` attribute for each `assertion_result` in a given `probe_result` will
                 # be identical, so we can create the tree node with the last `assertion_result`
                 if assertion_result:
@@ -101,7 +102,9 @@ class ProbeResultAggregator:
                 self._tree.show()
                 for e in filter(None, self._exceptions):
                     console.print(e)
-                console.print(f"\nTotal: 🟢 {passed}/{total} 🔴 {failed}/{total}")
+                pass_string = f"🟢 {passed}/{total}" if passed != 0 else ""
+                fail_string = f"🔴 {failed}/{total}" if failed != 0 else ""
+                console.print(f"\nTotal: {pass_string} {fail_string}")
             case "json":
                 tree_json = json.loads(self._tree.to_json())
                 # TODO see if treelib.Tree.to_json has an option to remove the "children" keys

--- a/tests/resources/probes/python/mixed.py
+++ b/tests/resources/probes/python/mixed.py
@@ -3,7 +3,7 @@ def status(juju_statuses):
 
 
 def bundle(juju_bundles):
-    assert True
+    assert False, "This should be False!"
 
 
 def show_unit(juju_show_units):

--- a/tests/resources/probes/python/mixed.py
+++ b/tests/resources/probes/python/mixed.py
@@ -1,6 +1,4 @@
-def status(juju_statuses):
-    raise Exception("I'm the status probe, and I failed")
-
+# This is intentionally missing the status function
 
 def bundle(juju_bundles):
     assert False, "This should be False!"

--- a/tests/resources/probes/ruleset/builtins.yaml
+++ b/tests/resources/probes/ruleset/builtins.yaml
@@ -1,5 +1,0 @@
-name: A declarative deployment RuleSet
-probes:
-  - name: Local probe - builtins
-    type: ruleset
-    with: something  # TODO Should you be able to supply a "url" and "with"?

--- a/tests/solution/test_command_check.py
+++ b/tests/solution/test_command_check.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 import pytest
 from typer.testing import CliRunner
@@ -7,59 +8,94 @@ from juju_doctor.main import app
 from juju_doctor.probes import AssertionStatus
 
 
-def test_check_multiple_artifacts():
-    # GIVEN a CLI Typer app
+def test_no_probes():
+    # GIVEN no probes were supplied
+    # WHEN `juju-doctor check` is executed
     runner = CliRunner()
-    # WHEN the "check" command is executed on a failing file probe
     test_args = [
         "check",
-        "--format",
-        "json",
-        "--probe",
-        "file://tests/resources/probes/python/passing.py",
+        "--format=json",
+        "--status=tests/resources/artifacts/status.yaml",
+    ]
+    result = runner.invoke(app, test_args)
+    # THEN the command fails
+    assert result.exit_code == 2
+    # AND the command fails
+    assert "No probes were specified" in result.output
+
+
+
+def test_no_artifacts():
+    # GIVEN no artifacts were supplied
+    # WHEN `juju-doctor check` is executed
+    runner = CliRunner()
+    test_args = [
+        "check",
+        "--format=json",
+        "--probe=file://tests/resources/probes/python/mixed.py",
+    ]
+    result = runner.invoke(app, test_args)
+    # THEN the command fails
+    assert result.exit_code == 2
+    # AND the command fails
+    assert "No artifacts were specified" in result.output
+
+
+def test_check_multiple_artifacts(caplog):
+    # GIVEN a file probe, missing the Status artifact
+    # AND all artifacts are supplied
+    # WHEN `juju-doctor check` is executed
+    runner = CliRunner()
+    test_args = [
+        "check",
+        "--format=json",
+        "--probe=file://tests/resources/probes/python/mixed.py",
         "--status=tests/resources/artifacts/status.yaml",
         "--bundle=tests/resources/artifacts/bundle.yaml",
+        "--show-unit=tests/resources/artifacts/show-unit.yaml",
     ]
-    result = runner.invoke(app, test_args)
+    with caplog.at_level("WARNING"):
+        result = runner.invoke(app, test_args)
     # THEN the command succeeds
     assert result.exit_code == 0
-    # AND only the status and bundle functions pass, since they were supplied an artifact
+    # AND only the functions with artifacts are executed
+    assert json.loads(result.stdout)["passed"] == 1
     assert json.loads(result.stdout)["failed"] == 1
-    assert json.loads(result.stdout)["passed"] == 2
+    # AND the user is warned of their mistake
+    assert re.search(r"status.*not used", caplog.text)
 
 
-def test_check_multiple_file_probes():
-    # GIVEN a CLI Typer app
+def test_check_multiple_file_probes(caplog):
+    # GIVEN multiple file probes and a Status artifact
+    # WHEN `juju-doctor check` is executed
     runner = CliRunner()
-    # WHEN the "check" command is executed on a complex ruleset probe
     test_args = [
         "check",
-        "--format",
-        "json",
-        "--probe",
-        "file://tests/resources/probes/python/passing.py",
-        "--probe",
-        "file://tests/resources/probes/python/failing.py",
+        "--format=json",
+        "--probe=file://tests/resources/probes/python/passing.py",
+        "--probe=file://tests/resources/probes/python/failing.py",
         "--status=tests/resources/artifacts/status.yaml",
     ]
-    result = runner.invoke(app, test_args)
+    with caplog.at_level("WARNING"):
+        result = runner.invoke(app, test_args)
     # THEN the command succeeds
     assert result.exit_code == 0
-    # AND only the status function passes, since it was supplied an artifact
-    assert json.loads(result.stdout)["failed"] == 5
+    # AND only the status functions are executed
+    assert json.loads(result.stdout)["failed"] == 1
     assert json.loads(result.stdout)["passed"] == 1
+    # AND the user is warned of their mistake
+    assert re.search(r"No 'bundle'.*provided", caplog.text)
+    assert re.search(r"No 'show_unit'.*provided", caplog.text)
 
 
 def test_check_returns_valid_json():
-    # GIVEN a CLI Typer app
+    # GIVEN any probe
+    # WHEN `juju-doctor check` is executed
     runner = CliRunner()
-    # WHEN the "check" command is executed on a complex ruleset probe
     test_args = [
         "check",
-        "--format",
-        "json",
-        "--probe",
-        "file://tests/resources/probes/ruleset/all.yaml",
+        "--format=json",
+        "--probe=file://tests/resources/probes/ruleset/all.yaml",
         "--status=tests/resources/artifacts/status.yaml",
     ]
     result = runner.invoke(app, test_args)
@@ -72,63 +108,57 @@ def test_check_returns_valid_json():
         assert False, f"Output is not valid JSON: {e}\nOutput:\n{result.output}"
 
 
-def test_duplicate_file_probes_are_excluded():
-    # GIVEN a CLI Typer app
+def test_duplicate_file_probes_are_excluded(caplog):
+    # GIVEN 2 duplicate file probes
+    # WHEN `juju-doctor check` is executed
     runner = CliRunner()
-    # WHEN the "check" command is supplied with 2 duplicate file probes
     test_args = [
         "check",
-        "--format",
-        "json",
-        "--probe",
-        "file://tests/resources/probes/python/failing.py",
-        "--probe",
-        "file://tests/resources/probes/python/failing.py",
+        "--format=json",
+        "--probe=file://tests/resources/probes/python/failing.py",
+        "--probe=file://tests/resources/probes/python/failing.py",
         "--status=tests/resources/artifacts/status.yaml",
     ]
-    result = runner.invoke(app, test_args)
+    with caplog.at_level("WARNING"):
+        result = runner.invoke(app, test_args)
     # THEN the command succeeds
     assert result.exit_code == 0
     # AND the second Probe overwrote the first, i.e. only 1 exists
     failing = json.loads(result.stdout)["Results"]["children"][0][AssertionStatus.FAIL.value]
     assert len(failing["children"]) == 1
+    # AND the user is warned of their mistake
+    assert re.search(r"Duplicate probe arg", caplog.text)
 
 
 @pytest.mark.github
 def test_check_gh_probe_at_branch():
-    # GIVEN a CLI Typer app
+    # GIVEN a GitHub probe on the main branch
+    # WHEN `juju-doctor check` is executed
     runner = CliRunner()
-    # WHEN the "check" command executes a GitHub probe on the main branch
     test_args = [
         "check",
-        "--format",
-        "json",
-        "--probe",
-        "github://canonical/juju-doctor//tests/resources/probes/python/failing.py?main",
-        "--status",
-        "tests/resources/artifacts/status.yaml",
+        "--format=json",
+        "--probe=github://canonical/juju-doctor//tests/resources/probes/python/failing.py?main",
+        "--status=tests/resources/artifacts/status.yaml",
     ]
     result = runner.invoke(app, test_args)
     # THEN the command succeeds
     assert result.exit_code == 0
     # AND the Probe was correctly executed
-    assert json.loads(result.stdout)["failed"] == 3
+    assert json.loads(result.stdout)["failed"] == 1
     assert json.loads(result.stdout)["passed"] == 0
 
 
 @pytest.mark.github
 def test_duplicate_gh_probes_are_excluded():
-    # GIVEN a CLI Typer app
+    # GIVEN two GitHub probes
+    # WHEN `juju-doctor check` is executed
     runner = CliRunner()
-    # WHEN the "check" command is supplied with 2 duplicate file probes
     test_args = [
         "check",
-        "--format",
-        "json",
-        "--probe",
-        "github://canonical/juju-doctor//tests/resources/probes/python/failing.py?main",
-        "--probe",
-        "github://canonical/juju-doctor//tests/resources/probes/python/failing.py?main",
+        "--format=json",
+        "--probe=github://canonical/juju-doctor//tests/resources/probes/python/failing.py?main",
+        "--probe=github://canonical/juju-doctor//tests/resources/probes/python/failing.py?main",
         "--status=tests/resources/artifacts/status.yaml",
     ]
     result = runner.invoke(app, test_args)

--- a/tests/unit/probe_result_aggregator/test_tree_result.py
+++ b/tests/unit/probe_result_aggregator/test_tree_result.py
@@ -33,10 +33,10 @@ def test_build_tree_status_group():
     expected_json = [
         {
             AssertionStatus.FAIL.value: {
-                "children": ["🔴 probes_python_failing.py (status, bundle, show_unit)"]
+                "children": ["🔴 probes_python_failing.py (✖️ status, ✖️ bundle, ✖️ show_unit)"]
             }
         },
-        {AssertionStatus.PASS.value: {"children": ["🟢 probes_python_passing.py"]}},
+        {AssertionStatus.PASS.value: {"children": ["🟢 probes_python_passing.py (✔️ status, ✔️ bundle, ✔️ show_unit)"]}},
     ]
 
     # GIVEN The results for 2 python probes (passing and failing)

--- a/tests/unit/probe_result_aggregator/test_tree_result.py
+++ b/tests/unit/probe_result_aggregator/test_tree_result.py
@@ -31,12 +31,8 @@ def probe_results(tmp_path: str, probe_name: str, passed: bool):
 
 def test_build_tree_status_group():
     expected_json = [
-        {
-            AssertionStatus.FAIL.value: {
-                "children": ["🔴 probes_python_failing.py (✖️ status, ✖️ bundle, ✖️ show_unit)"]
-            }
-        },
-        {AssertionStatus.PASS.value: {"children": ["🟢 probes_python_passing.py (✔️ status, ✔️ bundle, ✔️ show_unit)"]}},
+        {AssertionStatus.FAIL.value: {"children": ["🔴 probes_python_failing.py"]}},
+        {AssertionStatus.PASS.value: {"children": ["🟢 probes_python_passing.py"]}},
     ]
 
     # GIVEN The results for 2 python probes (passing and failing)

--- a/tests/unit/test_typer.py
+++ b/tests/unit/test_typer.py
@@ -1,0 +1,10 @@
+from juju_doctor.main import app
+
+
+def test_app_no_args_is_help():
+    # GIVEN juju-doctor and its registered commands
+    # WHEN no args are supplied to the app and/or commands
+    # THEN they show the help menu
+    assert app.info.no_args_is_help is True
+    for command in app.registered_commands:
+        assert command.no_args_is_help is True


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes #41 and parts of #43 as well as some minor untracked feedback from the sprint workshop.
The list of issues includes:
1. `juju-doctor help` creates a recursion error because the command calls itself.
2. CLI without args should return help
3. Probes which are not supplied the correct artifact should warn the user or supplied an unused artifact
4. No probes or artifacts supplied to `check` should error, since this is likely unintentional
5. The result format should be `fail/total` instead of just `fail` and include function level status information
6. Duplicate probes should not be executed and warn the user

## Solution
<!-- A summary of the solution addressing the above issue -->
### 1.
Force the user to use either `juju-doctor` or `juju-doctor --help` to get help. Where `juju-doctor help` returns:
```bash
juju-doctor help        
Usage: juju-doctor [OPTIONS] COMMAND [ARGS]...
Try 'juju-doctor --help' for help.
╭─ Error ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ No such command 'help'.                                                                                                                                                                           │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```
### 2.
`juju-doctor` and `juju-doctor check` now return the `--help` for each command.

### 3.
```
juju-doctor check --probe "file://tests/resources/probes/python/mixed.py" --show-unit tests/resources/artifacts/show-unit.yaml             
[05/20/25 23:00:20] WARNING  WARNING:juju_doctor.probes:No 'bundle' artifacts have been provided for probe:                                             probes.py:175
                             /tmp/tmp8lejk5rz/probes/tests_resources_probes_python_mixed.py.                                                                         
                    WARNING  WARNING:juju_doctor.probes:No 'status' artifacts have been provided for probe:                                             probes.py:175
                             /tmp/tmp8lejk5rz/probes/tests_resources_probes_python_mixed.py.
```
```
[05/21/25 17:53:53] WARNING  WARNING:__main__:The 'status' artifact was supplied, but not used by any probes.
```

### 4.
```
╭─ Error ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Invalid value: No probes were specified, cannot validate the deployment.                                                                                                         │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

### 5.
```
Results
└── fail
    └── 🔴 tests_resources_probes_python_mixed.py (✖️ bundle, ✔️ show_unit, ✖️ status)

Total: 🟢 1/3 🔴 2/3
```

### 6.
```
[05/18/25 10:45:36] WARNING  WARNING:__main__:Duplicate probe detected: file://tests/resources/probes/python/mixed.py, it will be skipped.                                main.py:81
[05/18/25 10:45:37] WARNING  WARNING:juju_doctor.fetcher:Duplicate file detected: tests/resources/probes/python/failing.py, it will be skipped.
```
Note: the duplicate file detection already existed on main, only duplicate `--probe` args in CLI or in Rulesets are now raised

## Testing
See updated unit and solution tests