### PR TITLE
Fix: Make helper functions importable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🩺 juju-doctor 🩺
 
 [![PyPI](https://img.shields.io/pypi/v/juju-doctor)](https://pypi.org/project/juju-doctor/)
-[![Release](https://github.com/canonical/juju-doctor/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/loki-k8s-operator/actions/workflows/release.yaml)
+[![Release](https://github.com/canonical/juju-doctor/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/juju-doctor/actions/workflows/release.yaml)
 
 Run a configurable set of `probes` (assertions) against Juju deployment `artifacts`, which are the output of other tools like `juju`, `sosreport`, and `kubectl`. To enforce best practices, these probes are organized into a `ruleset`, which acts as a guide for correct deployment configurations.
 

--- a/examples/gagent-proxy-redundant-downstream-integration.py
+++ b/examples/gagent-proxy-redundant-downstream-integration.py
@@ -15,6 +15,8 @@ from typing import Dict, Optional
 
 import yaml
 
+from juju_doctor.helpers import get_apps_by_charm_name
+
 
 def status(juju_statuses: Dict[str, Dict], **kwargs):
     """Status assertion for a cyclic relation between cos-proxy, grafana-agent, and prometheus.

--- a/examples/gagent-proxy-redundant-downstream-integration.py
+++ b/examples/gagent-proxy-redundant-downstream-integration.py
@@ -10,8 +10,7 @@ Context: As openstack incrementally transitioned from cos-proxy to grafana-agent
 ended up with hybrid, invalid topologies.
 """
 
-import contextlib
-from typing import Dict, Optional
+from typing import Dict
 
 import yaml
 
@@ -33,7 +32,6 @@ def status(juju_statuses: Dict[str, Dict], **kwargs):
 
     >>> status({"valid-model": example_status_valid()})
     """  # noqa: E501
-    assert False, f"WORKING: {get_apps_by_charm_name}"
     agent_and_proxy_rel = False
     suspicious_endpoint_apps = {}
     for status_name, status in juju_statuses.items():
@@ -82,22 +80,6 @@ def status(juju_statuses: Dict[str, Dict], **kwargs):
 # ==========================
 # Helper functions
 # ==========================
-
-
-def get_apps_by_charm_name(status: dict, charm_name: str) -> Dict[str, Dict]:
-    """Helper function to get the application object from a charm name."""
-    return {
-        app_name: context
-        for app_name, context in status.get("applications", {}).items()
-        if context["charm"] == charm_name
-    }
-
-
-def get_charm_name_by_app_name(status: dict, app_name: str) -> Optional[str]:
-    """Helper function to get the (predictable) charm name from an application name."""
-    with contextlib.suppress(KeyError):
-        return status["applications"][app_name]["charm"]
-    return None
 
 
 def example_status_cyclic_agent_cos_proxy():

--- a/examples/gagent-proxy-redundant-downstream-integration.py
+++ b/examples/gagent-proxy-redundant-downstream-integration.py
@@ -10,11 +10,10 @@ Context: As openstack incrementally transitioned from cos-proxy to grafana-agent
 ended up with hybrid, invalid topologies.
 """
 
-from typing import Dict
+import contextlib
+from typing import Dict, Optional
 
 import yaml
-
-from juju_doctor.probe_helpers import get_apps_by_charm_name
 
 
 def status(juju_statuses: Dict[str, Dict], **kwargs):
@@ -80,6 +79,22 @@ def status(juju_statuses: Dict[str, Dict], **kwargs):
 # ==========================
 # Helper functions
 # ==========================
+
+
+def get_apps_by_charm_name(status: dict, charm_name: str) -> Dict[str, Dict]:
+    """Helper function to get the application object from a charm name."""
+    return {
+        app_name: context
+        for app_name, context in status.get("applications", {}).items()
+        if context["charm"] == charm_name
+    }
+
+
+def get_charm_name_by_app_name(status: dict, app_name: str) -> Optional[str]:
+    """Helper function to get the (predictable) charm name from an application name."""
+    with contextlib.suppress(KeyError):
+        return status["applications"][app_name]["charm"]
+    return None
 
 
 def example_status_cyclic_agent_cos_proxy():

--- a/examples/gagent-proxy-redundant-downstream-integration.py
+++ b/examples/gagent-proxy-redundant-downstream-integration.py
@@ -33,6 +33,7 @@ def status(juju_statuses: Dict[str, Dict], **kwargs):
 
     >>> status({"valid-model": example_status_valid()})
     """  # noqa: E501
+    assert False, f"WORKING: {get_apps_by_charm_name}"
     agent_and_proxy_rel = False
     suspicious_endpoint_apps = {}
     for status_name, status in juju_statuses.items():

--- a/examples/gagent-related-twice-to-same-app.py
+++ b/examples/gagent-related-twice-to-same-app.py
@@ -10,11 +10,10 @@ Context: As openstack incrementally transitioned from cos-proxy to grafana-agent
 ended up with hybrid, invalid topologies.
 """
 
-from typing import Dict
+import contextlib
+from typing import Dict, Optional
 
 import yaml
-
-from juju_doctor.probe_helpers import get_apps_by_charm_name, get_charm_name_by_app_name
 
 
 def status(juju_statuses: Dict[str, Dict], **kwargs):
@@ -58,6 +57,22 @@ def status(juju_statuses: Dict[str, Dict], **kwargs):
 # ==========================
 # Helper functions
 # ==========================
+
+
+def get_apps_by_charm_name(status: dict, charm_name: str) -> Dict[str, Dict]:
+    """Helper function to get the application object from a charm name."""
+    return {
+        app_name: context
+        for app_name, context in status.get("applications", {}).items()
+        if context["charm"] == charm_name
+    }
+
+
+def get_charm_name_by_app_name(status: dict, app_name: str) -> Optional[str]:
+    """Helper function to get the (predictable) charm name from an application name."""
+    with contextlib.suppress(KeyError):
+        return status["applications"][app_name]["charm"]
+    return None
 
 
 def example_status_redundant_endpoints_agent_cos_proxy():

--- a/examples/gagent-related-twice-to-same-app.py
+++ b/examples/gagent-related-twice-to-same-app.py
@@ -10,10 +10,11 @@ Context: As openstack incrementally transitioned from cos-proxy to grafana-agent
 ended up with hybrid, invalid topologies.
 """
 
-import contextlib
-from typing import Dict, Optional
+from typing import Dict
 
 import yaml
+
+from juju_doctor.helpers import get_apps_by_charm_name, get_charm_name_by_app_name
 
 
 def status(juju_statuses: Dict[str, Dict], **kwargs):
@@ -43,8 +44,7 @@ def status(juju_statuses: Dict[str, Dict], **kwargs):
 
         # Assert that either juju-info or cos-agent exists per app, not both
         for agent, related_app in apps_related_to_agent.get("cos-agent", {}):
-            # other_charm = get_charm_name_by_app_name(status, related_app)
-            other_charm = get_charm_name_by_app_name(status, "fart")
+            other_charm = get_charm_name_by_app_name(status, related_app)
             for _, _related_app in apps_related_to_agent.get("juju-info", {}):
                 assert related_app != _related_app, (
                     f'Remove either the "juju-info" or "cos-agent" integration between "{agent}" '
@@ -57,22 +57,6 @@ def status(juju_statuses: Dict[str, Dict], **kwargs):
 # ==========================
 # Helper functions
 # ==========================
-
-
-def get_apps_by_charm_name(status: dict, charm_name: str) -> Dict[str, Dict]:
-    """Helper function to get the application object from a charm name."""
-    return {
-        app_name: context
-        for app_name, context in status.get("applications", {}).items()
-        if context["charm"] == charm_name
-    }
-
-
-def get_charm_name_by_app_name(status: dict, app_name: str) -> Optional[str]:
-    """Helper function to get the (predictable) charm name from an application name."""
-    with contextlib.suppress(KeyError):
-        return status["applications"][app_name]["charm"]
-    return None
 
 
 def example_status_redundant_endpoints_agent_cos_proxy():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "juju-doctor"
-version = "0.1.6"
+version = "0.1.8"
 description = "Juju-doctor is a pypi package which helps validate Juju deployments using probes."
 license = { file = "LICENSE" }
 readme = "README.md"

--- a/src/juju_doctor/helpers.py
+++ b/src/juju_doctor/helpers.py
@@ -4,7 +4,7 @@ These functions simplify the artifact (status, bundle, etc.) content parsing.
 
 Add this line to your probe and you have access to all these functions:
 
-`from juju_doctor.probe_helpers import PICK_YOUR_FUNCTION`
+`from juju_doctor.helpers import PICK_YOUR_FUNCTION`
 """
 import contextlib
 from typing import Dict, Optional

--- a/src/juju_doctor/probes.py
+++ b/src/juju_doctor/probes.py
@@ -257,7 +257,7 @@ class Probe:
         """
         # module from filesystem path
         if self.probes_root:
-            package_name = ""
+            package_name = "juju_doctor"
             source_path = Path(self.path).resolve()
             src_text = source_path.read_text()
             origin = str(source_path)

--- a/src/juju_doctor/probes.py
+++ b/src/juju_doctor/probes.py
@@ -255,15 +255,15 @@ class Probe:
         We import the module dynamically because the path of the probe is only known at runtime.
         Only returns the supported 'status', 'bundle', and 'show_unit' functions (if present).
         """
+        package_name = "juju_doctor"
+
         # module from filesystem path
         if self.probes_root:
-            package_name = "juju_doctor"
             source_path = Path(self.path).resolve()
             src_text = source_path.read_text()
             origin = str(source_path)
         # module from package resources (wheel or source)
         else:
-            package_name = "juju_doctor"
             resource = resources.files(package_name).joinpath(str(self.path))
             src_text = resource.read_text()
             origin = f"{package_name}/{self.path}"
@@ -273,7 +273,7 @@ class Probe:
         module = types.ModuleType(module_name)
         module.__file__ = origin
         # ff the probe is inside the package, set a package context so relative imports work
-        module.__package__ = package_name or None
+        module.__package__ = package_name
         sys.modules[module_name] = module
 
         exec(compile(src_text, origin, "exec"), module.__dict__)

--- a/uv.lock
+++ b/uv.lock
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "juju-doctor"
-version = "0.1.6"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "fsspec" },


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Helper functions were not importable due to the relative package ref being broken on loading dynamic probes.

## Solution
<!-- A summary of the solution addressing the above issue -->
Set `package_name = "juju_doctor"`
Some minor repo cleanup was also needed.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
`uvx --from "git+https://github.com/canonical/juju-doctor@fix/helpers" juju-doctor check --probe="github://canonical/juju-doctor//examples?fix/helpers" --status=<(juju status --format=yaml) --verbose`