### PR TITLE
Remove PyPI and Release badges from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # 🩺 juju-doctor 🩺
 
-[![PyPI](https://img.shields.io/pypi/v/juju-doctor)](https://pypi.org/project/juju-doctor/)
-[![Release](https://github.com/canonical/juju-doctor/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/juju-doctor/actions/workflows/release.yaml)
-
 Run a configurable set of `probes` (assertions) against Juju deployment `artifacts`, which are the output of other tools like `juju`, `sosreport`, and `kubectl`. To enforce best practices, these probes are organized into a `ruleset`, which acts as a guide for correct deployment configurations.
 
 ## Usage


### PR DESCRIPTION
Removed badges from the README file as they lag behind and are not professional.
